### PR TITLE
fix: 修复美团菜品映射接口更新后，无法进行菜品映射问题

### DIFF
--- a/src/Application/Waimai/Dish/Dish.php
+++ b/src/Application/Waimai/Dish/Dish.php
@@ -64,11 +64,15 @@ class Dish extends Api
      */
     public function getDishMapUrl($ePoiId)
     {
-        return self::DISH_MAPPING_API . '?' . http_build_query([
-                'signKey'      => $this->accessToken->getSignKey(),
-                'appAuthToken' => $this->accessToken->getAuthToken(),
-                'ePoiId'       => $ePoiId,
-            ]);
+        $params = [
+            'ePoiId' => $ePoiId,
+            'appAuthToken' => $this->accessToken->getAuthToken(),
+            'timestamp' => time(),
+        ];
+
+        $params['sign'] = $this->accessToken->signature($params);
+
+        return self::DISH_MAPPING_API . '?' . http_build_query($params);
     }
 
     /**


### PR DESCRIPTION
https://developer.meituan.com/openapi#7.2.3 接口有变动。原有的会提示签名错误